### PR TITLE
Modernize ui-helper-hidden-accessible

### DIFF
--- a/themes/base/core.css
+++ b/themes/base/core.css
@@ -16,13 +16,15 @@
 }
 .ui-helper-hidden-accessible {
 	border: 0;
-	clip: rect(0 0 0 0);
-	height: 1px;
-	margin: -1px;
-	overflow: hidden;
 	padding: 0;
-	position: absolute;
+	margin: 0;
+	position: absolute !important;
+	height: 1px;
 	width: 1px;
+	overflow: hidden;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	white-space: nowrap;
 }
 .ui-helper-reset {
 	margin: 0;


### PR DESCRIPTION
Based on this https://stackoverflow.com/a/62109988/502366

This jQuery style for screenreaders has not changed in a long time but now that browser have advanced it is missing some features explained in the stack overflow.

```css
    border: 0;
    padding: 0;
    margin: 0;
    position: absolute !important;
    height: 1px; 
    width: 1px;
    overflow: hidden;
    clip: rect(1px, 1px, 1px, 1px); /*maybe deprecated but we need to support legacy browsers */
    clip-path: inset(50%); /*modern browsers, clip-path works inwards from each corner*/
    white-space: nowrap; /* added line to stop words getting smushed together (as they go onto seperate lines and some screen readers do not understand line feeds as a space */
```